### PR TITLE
Use simpler role name

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 galaxy_info:
+  role_name: openjdk
   author: 'Fran Rodríguez'
   description: 'Manage Java OpenJRE/OpenJDK environment'
   company: 'DEVO Inc.'


### PR DESCRIPTION
This change will allow to install from galaxy using `devoinc.openjdk`, instead of `devoinc.ansible-java`